### PR TITLE
MT-13 Removed CRTP, downcasting and backdoor access to private functi…

### DIFF
--- a/src/api/crypto/blockchain/BalanceOracle.cpp
+++ b/src/api/crypto/blockchain/BalanceOracle.cpp
@@ -396,6 +396,10 @@ auto BalanceOracle::Imp::UpdateBalance(
     }());
 }
 
+auto BalanceOracle::Imp::do_startup() noexcept -> void {}
+
+auto BalanceOracle::Imp::do_shutdown() noexcept -> void {}
+
 auto BalanceOracle::Imp::work() noexcept -> bool { return false; }
 
 BalanceOracle::Imp::~Imp() { signal_shutdown(); }

--- a/src/api/crypto/blockchain/BalanceOracle.hpp
+++ b/src/api/crypto/blockchain/BalanceOracle.hpp
@@ -50,7 +50,7 @@ class Raw;
 
 namespace opentxs::api::crypto::blockchain
 {
-class BalanceOracle::Imp final : public opentxs::Actor<Imp, BalanceOracleJobs>
+class BalanceOracle::Imp final : public opentxs::Actor<BalanceOracleJobs>
 {
 public:
     auto UpdateBalance(const Chain chain, const Balance balance) const noexcept
@@ -72,9 +72,13 @@ public:
 
     ~Imp() final;
 
-private:
-    friend opentxs::Actor<Imp, BalanceOracleJobs>;
+protected:
+    auto do_startup() noexcept -> void override;
+    auto do_shutdown() noexcept -> void override;
+    auto pipeline(const Work work, Message&& msg) noexcept -> void override;
+    auto work() noexcept -> bool override;
 
+private:
     using Subscribers = Set<OTData>;
     using Data = std::pair<Balance, Subscribers>;
     using NymData = Map<OTNymID, Data>;
@@ -92,8 +96,6 @@ private:
         const Balance& balance,
         const WorkType type) const noexcept -> Message;
 
-    auto do_shutdown() noexcept -> void {}
-    auto do_startup() noexcept -> void {}
     auto notify_subscribers(
         const Subscribers& recipients,
         const Balance& balance,
@@ -103,7 +105,6 @@ private:
         const identifier::Nym& owner,
         const Balance& balance,
         const Chain chain) noexcept -> void;
-    auto pipeline(const Work work, Message&& msg) noexcept -> void;
     auto process_registration(Message&& in) noexcept -> void;
     auto process_update_balance(const Chain chain, Balance balance) noexcept
         -> void;
@@ -113,6 +114,5 @@ private:
         Balance balance) noexcept -> void;
     auto process_update_chain_balance(Message&& in) noexcept -> void;
     auto process_update_nym_balance(Message&& in) noexcept -> void;
-    auto work() noexcept -> bool;
 };
 }  // namespace opentxs::api::crypto::blockchain

--- a/src/blockchain/node/blockoracle/BlockOracle.hpp
+++ b/src/blockchain/node/blockoracle/BlockOracle.hpp
@@ -100,7 +100,7 @@ class Message;
 
 namespace opentxs::blockchain::node::internal
 {
-class BlockOracle::Imp final : public Actor<Imp, BlockOracleJobs>
+class BlockOracle::Imp final : public Actor<BlockOracleJobs>
 {
 public:
     auto DownloadQueue() const noexcept -> std::size_t
@@ -143,9 +143,13 @@ public:
 
     ~Imp() final;
 
-private:
-    friend Actor<Imp, BlockOracleJobs>;
+protected:
+    auto do_startup() noexcept -> void override;
+    auto do_shutdown() noexcept -> void override;
+    auto pipeline(const Work work, Message&& msg) noexcept -> void override;
+    auto work() noexcept -> bool override;
 
+private:
     using Task = BlockOracleJobs;
     using Cache =
         libguarded::shared_guarded<blockoracle::Cache, std::shared_mutex>;
@@ -162,11 +166,6 @@ private:
         const blockchain::Type chain,
         const node::HeaderOracle& headers) noexcept
         -> std::unique_ptr<const internal::BlockValidator>;
-
-    auto do_shutdown() noexcept -> void;
-    auto do_startup() noexcept -> void;
-    auto pipeline(const Work work, Message&& msg) noexcept -> void;
-    auto work() noexcept -> bool;
 
     Imp(const api::Session& api,
         const internal::Network& node,

--- a/src/blockchain/node/p2p/Requestor.hpp
+++ b/src/blockchain/node/p2p/Requestor.hpp
@@ -68,7 +68,7 @@ class Message;
 
 namespace opentxs::blockchain::node::p2p
 {
-class Requestor::Imp final : public Actor<Imp, network::p2p::Job>
+class Requestor::Imp final : public Actor<network::p2p::Job>
 {
 public:
     auto Init(boost::shared_ptr<Imp> me) noexcept -> void
@@ -85,9 +85,13 @@ public:
 
     ~Imp() final;
 
-private:
-    friend Actor<Imp, network::p2p::Job>;
+protected:
+    auto do_startup() noexcept -> void override;
+    auto do_shutdown() noexcept -> void override;
+    auto pipeline(const Work work, Message&& msg) noexcept -> void override;
+    auto work() noexcept -> bool override;
 
+private:
     enum class State { init, sync, run };
 
     static constexpr std::size_t limit_{32_MiB};
@@ -126,13 +130,10 @@ private:
     auto check_remote_position() noexcept -> void;
     auto do_common() noexcept -> void;
     auto do_init() noexcept -> void;
-    auto do_shutdown() noexcept -> void;
-    auto do_startup() noexcept -> void;
     auto do_run() noexcept -> void;
     auto do_sync() noexcept -> void;
     auto have_pending_request() noexcept -> bool;
     auto need_sync() noexcept -> bool;
-    auto pipeline(const Work work, Message&& msg) noexcept -> void;
     auto process_push_tx(Message&& in) noexcept -> void;
     auto process_sync_ack(Message&& in) noexcept -> void;
     auto process_sync_processed(Message&& in) noexcept -> void;
@@ -159,7 +160,6 @@ private:
         -> void;
     auto update_remote_position(const network::p2p::State& state) noexcept
         -> void;
-    auto work() noexcept -> bool;
 
     Imp() = delete;
     Imp(const Imp&) = delete;

--- a/src/blockchain/node/wallet/Account.hpp
+++ b/src/blockchain/node/wallet/Account.hpp
@@ -103,7 +103,7 @@ class Identifier;
 
 namespace opentxs::blockchain::node::wallet
 {
-class Account::Imp final : public Actor<Imp, AccountJobs>
+class Account::Imp final : public Actor<AccountJobs>
 {
 public:
     auto VerifyState(const State state) const noexcept -> void;
@@ -130,9 +130,13 @@ public:
 
     ~Imp() final { signal_shutdown(); }
 
-private:
-    friend Actor<Imp, AccountJobs>;
+protected:
+    auto do_startup() noexcept -> void override;
+    auto do_shutdown() noexcept -> void override;
+    auto pipeline(const Work work, Message&& msg) noexcept -> void override;
+    auto work() noexcept -> bool override;
 
+private:
     using Subchains = Map<OTIdentifier, boost::shared_ptr<SubchainStateData>>;
     using HandledReorgs = Set<StateSequence>;
 
@@ -161,8 +165,6 @@ private:
     auto check_pc(const Identifier& subaccount) noexcept -> void;
     auto check_pc(const crypto::PaymentCode& subaccount) noexcept -> void;
     auto clear_children() noexcept -> void;
-    auto do_shutdown() noexcept -> void;
-    auto do_startup() noexcept -> void;
     template <typename Callback>
     auto for_each(const Callback& cb) noexcept -> void
     {
@@ -181,7 +183,6 @@ private:
         const crypto::Deterministic& subaccount,
         const crypto::Subchain subchain,
         Subchains& map) noexcept -> Subchain&;
-    auto pipeline(const Work work, Message&& msg) noexcept -> void;
     auto process_key(Message&& in) noexcept -> void;
     auto process_prepare_reorg(Message&& in) noexcept -> void;
     auto process_rescan(Message&& in) noexcept -> void;
@@ -195,7 +196,6 @@ private:
     auto transition_state_normal() noexcept -> bool;
     auto transition_state_reorg(StateSequence id) noexcept -> bool;
     auto transition_state_shutdown() noexcept -> bool;
-    auto work() noexcept -> bool;
 
     Imp(const api::Session& api,
         const crypto::Account& account,

--- a/src/blockchain/node/wallet/Accounts.hpp
+++ b/src/blockchain/node/wallet/Accounts.hpp
@@ -88,7 +88,7 @@ class Identifier;
 
 namespace opentxs::blockchain::node::wallet
 {
-class Accounts::Imp final : public Actor<Imp, AccountsJobs>
+class Accounts::Imp final : public Actor<AccountsJobs>
 {
 public:
     auto Rescan() const noexcept -> void;
@@ -109,9 +109,13 @@ public:
 
     ~Imp() final;
 
-private:
-    friend Actor<Imp, AccountsJobs>;
+protected:
+    auto do_startup() noexcept -> void override;
+    auto do_shutdown() noexcept -> void override;
+    auto pipeline(const Work work, Message&& msg) noexcept -> void override;
+    auto work() noexcept -> bool override;
 
+private:
     enum class State {
         normal,
         shutdown,
@@ -133,14 +137,11 @@ private:
     std::optional<StateSequence> startup_reorg_;
 
     auto do_reorg() noexcept -> void;
-    auto do_shutdown() noexcept -> void;
-    auto do_startup() noexcept -> void;
     template <typename Callback>
     auto for_each(const Callback& cb) noexcept -> void
     {
         std::for_each(accounts_.begin(), accounts_.end(), cb);
     }
-    auto pipeline(const Work work, Message&& msg) noexcept -> void;
     auto process_block_header(Message&& in) noexcept -> void;
     auto process_nym(Message&& in) noexcept -> bool;
     auto process_nym(const identifier::Nym& nym) noexcept -> bool;
@@ -153,7 +154,6 @@ private:
     auto state_normal(const Work work, Message&& msg) noexcept -> void;
     auto transition_state_shutdown() noexcept -> void;
     auto transition_state_reorg() noexcept -> bool;
-    auto work() noexcept -> bool;
 
     Imp(const api::Session& api,
         const node::internal::Network& node,

--- a/src/blockchain/node/wallet/subchain/SubchainStateData.hpp
+++ b/src/blockchain/node/wallet/subchain/SubchainStateData.hpp
@@ -136,7 +136,7 @@ namespace opentxs::blockchain::node::wallet
 {
 class SubchainStateData
     : virtual public Subchain,
-      public Actor<SubchainStateData, SubchainJobs>,
+      public Actor<SubchainJobs>,
       public boost::enable_shared_from_this<SubchainStateData>
 {
 public:
@@ -226,11 +226,13 @@ public:
     ~SubchainStateData() override;
 
 protected:
+    auto do_startup() noexcept -> void override;
+    auto do_shutdown() noexcept -> void override;
+    auto pipeline(const Work work, Message&& msg) noexcept -> void override;
+    auto work() noexcept -> bool override;
+
     using TXOs = WalletDatabase::TXOs;
     auto set_key_data(block::bitcoin::Transaction& tx) const noexcept -> void;
-
-    virtual auto do_startup() noexcept -> void;
-    virtual auto work() noexcept -> bool;
 
     SubchainStateData(
         const api::Session& api,
@@ -244,9 +246,8 @@ protected:
         const std::string_view parent,
         allocator_type alloc) noexcept;
 
-private:
-    friend Actor<SubchainStateData, SubchainJobs>;
 
+private:
     using Transactions =
         Vector<std::shared_ptr<const block::bitcoin::Transaction>>;
     using Task = node::internal::Wallet::Task;
@@ -365,8 +366,6 @@ private:
         storage::lmdb::LMDB::Transaction& tx,
         std::atomic_int& errors,
         const block::Position ancestor) noexcept -> void;
-    auto do_shutdown() noexcept -> void;
-    auto pipeline(const Work work, Message&& msg) noexcept -> void;
     auto process_prepare_reorg(Message&& in) noexcept -> void;
     auto process_rescan(Message&& in) noexcept -> void;
     auto process_watchdog_ack(Message&& in) noexcept -> void;

--- a/src/blockchain/node/wallet/subchain/statemachine/Index.hpp
+++ b/src/blockchain/node/wallet/subchain/statemachine/Index.hpp
@@ -73,6 +73,7 @@ public:
     ~Imp() override = default;
 
 protected:
+    auto do_startup() noexcept -> void final;
     auto done(node::internal::WalletDatabase::ElementMap&& elements) noexcept
         -> void;
 
@@ -84,7 +85,6 @@ private:
         const noexcept -> std::optional<Bip32Index> = 0;
 
     auto do_process_update(Message&& msg) noexcept -> void final;
-    auto do_startup() noexcept -> void final;
     virtual auto process(
         const std::optional<Bip32Index>& current,
         Bip32Index target) noexcept -> void = 0;

--- a/src/blockchain/node/wallet/subchain/statemachine/Job.cpp
+++ b/src/blockchain/node/wallet/subchain/statemachine/Job.cpp
@@ -199,6 +199,7 @@ auto Job::do_process_update(Message&& msg) noexcept -> void
 }
 
 auto Job::do_shutdown() noexcept -> void {}
+auto Job::do_startup() noexcept -> void {}
 
 auto Job::last_reorg() const noexcept -> std::optional<StateSequence>
 {


### PR DESCRIPTION
MT-13 Remove downcast.

This change is part one of a wider stability refactoring. In place of downcast calls directly to the direct subclasses of Actor, we now call on virtual functions. The friend class relationships that were needed to call private functions have been removed and the private access now provides the usual guarantee.
