### PR TITLE
MT-25 Remove CRTP and protection violations from Worker based classes

### DIFF
--- a/include/opentxs/network/zeromq/message/Frame.hpp
+++ b/include/opentxs/network/zeromq/message/Frame.hpp
@@ -81,6 +81,7 @@ public:
     auto Bytes() const noexcept -> ReadView;
     OPENTXS_NO_EXPORT auto Internal() const noexcept -> const internal::Frame&;
     auto data() const noexcept -> const void*;
+    auto data() noexcept -> void*;
     auto size() const noexcept -> std::size_t;
 
     operator zmq_msg_t*() noexcept;

--- a/src/api/network/blockchain/Imp.cpp
+++ b/src/api/network/blockchain/Imp.cpp
@@ -487,7 +487,7 @@ auto BlockchainImp::Shutdown() noexcept -> void
         LogVerbose()("Shutting down ")(networks_.size())(" blockchain clients")
             .Flush();
 
-        for (auto& [chain, network] : networks_) { network->Shutdown().get(); }
+        for (auto& [chain, network] : networks_) { network->Shutdown(); }
 
         networks_.clear();
     }
@@ -610,7 +610,7 @@ auto BlockchainImp::stop(const Lock& lock, const Chain type) const noexcept
     OT_ASSERT(it->second);
 
     sync_server_.Disable(type);
-    it->second->Shutdown().get();
+    it->second->Shutdown();
     networks_.erase(it);
     LogVerbose()(OT_PRETTY_CLASS())("stopped chain ")(print(type)).Flush();
     publish_chain_state(type, false);

--- a/src/blockchain/database/common/Peers.cpp
+++ b/src/blockchain/database/common/Peers.cpp
@@ -202,10 +202,10 @@ auto Peers::Import(UnallocatedVector<Address_p> peers) noexcept -> bool
     return insert(lock, std::move(newPeers));
 }
 
-auto Peers::Insert(Address_p pAddress) noexcept -> bool
+auto Peers::Insert(Address_p&& pAddress) noexcept -> bool
 {
     auto peers = UnallocatedVector<Address_p>{};
-    peers.emplace_back(std::move(pAddress));
+    peers.push_back(std::move(pAddress));
     Lock lock(lock_);
 
     return insert(lock, std::move(peers));
@@ -213,18 +213,18 @@ auto Peers::Insert(Address_p pAddress) noexcept -> bool
 
 auto Peers::insert(
     const Lock& lock,
-    UnallocatedVector<Address_p> peers) noexcept -> bool
+    UnallocatedVector<Address_p>&& peers) noexcept -> bool
 {
     auto parentTxn = lmdb_.TransactionRW();
 
-    for (auto& pAddress : peers) {
+    for (const auto& pAddress : peers) {
         if (false == bool(pAddress)) {
             LogError()(OT_PRETTY_CLASS())("Invalid peer").Flush();
 
             return false;
         }
 
-        auto& address = *pAddress;
+        const auto& address = *pAddress;
         const auto id = address.ID().str();
         auto deleteServices = address.PreviousServices();
 

--- a/src/blockchain/database/common/Peers.hpp
+++ b/src/blockchain/database/common/Peers.hpp
@@ -53,7 +53,7 @@ public:
         const UnallocatedSet<Service> withServices) const noexcept -> Address_p;
 
     auto Import(UnallocatedVector<Address_p> peers) noexcept -> bool;
-    auto Insert(Address_p address) noexcept -> bool;
+    auto Insert(Address_p&& address) noexcept -> bool;
 
     Peers(const api::Session& api, storage::lmdb::LMDB& lmdb) noexcept(false);
 
@@ -77,7 +77,7 @@ private:
     TypeIndexMap networks_;
     ConnectedIndexMap connected_;
 
-    auto insert(const Lock& lock, UnallocatedVector<Address_p> peers) noexcept
+    auto insert(const Lock& lock, UnallocatedVector<Address_p>&& peers) noexcept
         -> bool;
     auto load_address(const UnallocatedCString& id) const noexcept(false)
         -> Address_p;

--- a/src/blockchain/node/filteroracle/FilterOracle.hpp
+++ b/src/blockchain/node/filteroracle/FilterOracle.hpp
@@ -195,7 +195,6 @@ public:
     ~FilterOracle() final;
 
 private:
-    friend Worker<FilterOracle, api::Session>;
     friend internal::FilterOracle;
 
     using FilterHeaderHex = UnallocatedCString;

--- a/src/blockchain/node/wallet/feeoracle/FeeOracle.hpp
+++ b/src/blockchain/node/wallet/feeoracle/FeeOracle.hpp
@@ -63,7 +63,7 @@ class Timer;
 
 class opentxs::blockchain::node::wallet::FeeOracle::Imp final
     : public opentxs::implementation::Allocated,
-      public Worker<Imp, api::Session>
+      public Worker<api::Session>
 {
 public:
     enum class Work : OTZMQWorkType {
@@ -85,8 +85,14 @@ public:
 
     ~Imp() final;
 
+protected:
+    auto pipeline(network::zeromq::Message&&) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
+
 private:
-    friend Worker<Imp, api::Session>;
+    auto shut_down() noexcept -> void;
+
+private:
     using Data = Vector<std::pair<Time, Amount>>;
     using Estimate =
         libguarded::deferred_guarded<std::optional<Amount>, std::shared_mutex>;
@@ -96,9 +102,6 @@ private:
     Data data_;
     Estimate output_;
 
-    auto pipeline(network::zeromq::Message&&) noexcept -> void;
     auto process_update(network::zeromq::Message&&) noexcept -> void;
     auto reset_timer() noexcept -> void;
-    auto state_machine() noexcept -> bool;
-    auto shutdown(std::promise<void>&) noexcept -> void;
 };

--- a/src/blockchain/node/wallet/feeoracle/FeeSource.hpp
+++ b/src/blockchain/node/wallet/feeoracle/FeeSource.hpp
@@ -63,7 +63,7 @@ class Timer;
 
 class opentxs::blockchain::node::wallet::FeeSource::Imp
     : public opentxs::implementation::Allocated,
-      public Worker<Imp, api::Session>
+      public Worker<api::Session>
 {
 public:
     const CString hostname_;
@@ -83,6 +83,13 @@ public:
     ~Imp() override;
 
 protected:
+    auto pipeline(network::zeromq::Message&&) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
+
+private:
+    auto shut_down() noexcept -> void;
+
+protected:
     auto process_double(double rate, unsigned long long int scale) noexcept
         -> std::optional<Amount>;
     auto process_int(std::int64_t rate, unsigned long long int scale) noexcept
@@ -96,8 +103,6 @@ protected:
         allocator_type&& alloc) noexcept;
 
 private:
-    friend Worker<Imp, api::Session>;
-
     static const display::Scale scale_;
 
     std::random_device rd_;
@@ -111,10 +116,7 @@ private:
     virtual auto process(const boost::json::value& data) noexcept
         -> std::optional<Amount> = 0;
 
-    auto pipeline(network::zeromq::Message&&) noexcept -> void;
     auto query() noexcept -> void;
     auto reset_timer() noexcept -> void;
-    auto shutdown(std::promise<void>&) noexcept -> void;
     auto startup() noexcept -> void;
-    auto state_machine() noexcept -> bool;
 };

--- a/src/blockchain/p2p/Address.cpp
+++ b/src/blockchain/p2p/Address.cpp
@@ -88,6 +88,8 @@ namespace opentxs::blockchain::p2p::implementation
 {
 const VersionNumber Address::DefaultVersion{1};
 
+Address::~Address() {}
+
 Address::Address(
     const api::Session& api,
     const VersionNumber version,
@@ -150,20 +152,20 @@ Address::Address(
     }
 }
 
-Address::Address(const Address& rhs) noexcept
-    : api_(rhs.api_)
-    , version_(rhs.version_)
-    , id_(rhs.id_)
-    , protocol_(rhs.protocol_)
-    , network_(rhs.network_)
-    , bytes_(rhs.bytes_)
-    , port_(rhs.port_)
-    , chain_(rhs.chain_)
-    , previous_last_connected_(rhs.previous_last_connected_)
-    , previous_services_(rhs.previous_services_)
-    , incoming_(rhs.incoming_)
-    , last_connected_(rhs.last_connected_)
-    , services_(rhs.services_)
+Address::Address(const Address* rhs) noexcept
+    : api_(rhs->api_)
+    , version_(rhs->version_)
+    , id_(rhs->id_)
+    , protocol_(rhs->protocol_)
+    , network_(rhs->network_)
+    , bytes_(rhs->bytes_)
+    , port_(rhs->port_)
+    , chain_(rhs->chain_)
+    , previous_last_connected_(rhs->previous_last_connected_)
+    , previous_services_(rhs->previous_services_)
+    , incoming_(rhs->incoming_)
+    , last_connected_(rhs->last_connected_)
+    , services_(rhs->services_)
 {
 }
 

--- a/src/blockchain/p2p/Address.hpp
+++ b/src/blockchain/p2p/Address.hpp
@@ -96,9 +96,10 @@ public:
         const Time lastConnected,
         const UnallocatedSet<Service>& services,
         const bool incoming) noexcept(false);
-    Address(const Address& rhs) noexcept;
 
-    ~Address() final = default;
+    ~Address() final;
+
+    Address(const Address* rhs) noexcept;
 
 private:
     const api::Session& api_;
@@ -133,14 +134,15 @@ private:
         const Time lastConnected,
         const UnallocatedSet<Service>& services) noexcept -> SerializedType;
 
-    auto clone() const noexcept -> Address* final { return new Address(*this); }
+    auto clone() const noexcept -> Address* final { return new Address(this); }
     auto clone_internal() const noexcept
         -> std::unique_ptr<internal::Address> final
     {
-        return std::make_unique<Address>(*this);
+        return std::make_unique<Address>(this);
     }
 
     Address() = delete;
+    Address(const Address&) = delete;
     Address(Address&&) = delete;
     auto operator=(const Address&) -> Address& = delete;
     auto operator=(Address&&) -> Address& = delete;

--- a/src/blockchain/p2p/peer/Address.cpp
+++ b/src/blockchain/p2p/peer/Address.cpp
@@ -22,6 +22,8 @@ Address::Address(std::unique_ptr<internal::Address> address) noexcept
     OT_ASSERT(address_);
 }
 
+Address::~Address() {}
+
 auto Address::Bytes() const noexcept -> OTData
 {
     Lock lock(lock_);
@@ -39,7 +41,6 @@ auto Address::Chain() const noexcept -> blockchain::Type
 auto Address::Display() const noexcept -> UnallocatedCString
 {
     Lock lock(lock_);
-
     return address_->Display();
 }
 
@@ -91,7 +92,6 @@ auto Address::UpdateTime(const Time& time) noexcept -> pointer
 {
     Lock lock(lock_);
     address_->SetLastConnected(time);
-
     return address_->clone_internal();
 }
 }  // namespace opentxs::blockchain::p2p::peer

--- a/src/blockchain/p2p/peer/Address.hpp
+++ b/src/blockchain/p2p/peer/Address.hpp
@@ -65,6 +65,10 @@ public:
 
     Address(pointer address) noexcept;
 
+    virtual ~Address();
+
+    operator bool() { return address_ != nullptr; }
+
 private:
     mutable std::mutex lock_;
     pointer address_;

--- a/src/core/Worker.hpp
+++ b/src/core/Worker.hpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <functional>
 #include <future>
+#include <mutex>
 
 #include "internal/network/zeromq/Context.hpp"
 #include "internal/network/zeromq/Types.hpp"
@@ -45,17 +46,29 @@ class Client;
 
 namespace opentxs
 {
-template <typename Child, typename API = api::session::Client>
+template <typename API = api::session::Client>
 class Worker
 {
+protected:
+    virtual auto pipeline(network::zeromq::Message&& in) noexcept -> void = 0;
+    virtual auto state_machine() noexcept -> bool = 0;
+
 protected:
     using Endpoints = UnallocatedVector<UnallocatedCString>;
 
     const API& api_;
     const std::chrono::milliseconds rate_limit_;
     std::atomic<bool> running_;
+
+private:
     std::promise<void> shutdown_promise_;
-    std::shared_future<void> shutdown_;
+    std::shared_future<void> shutdown_complete_;
+    std::mutex shutdown_mutex_;
+
+    Time last_executed_;
+    mutable std::atomic<bool> state_machine_queued_;
+
+protected:
     network::zeromq::Pipeline pipeline_;
 
     auto trigger() const noexcept -> void
@@ -68,16 +81,19 @@ protected:
             pipeline_.Push(MakeWork(OT_ZMQ_STATE_MACHINE_SIGNAL));
         }
     }
-    auto signal_shutdown() const noexcept -> std::shared_future<void>
+    auto signal_shutdown() noexcept -> std::shared_future<void>
     {
-        return const_cast<Worker&>(*this).stop_worker();
+        protect_shutdown([this] { close_pipeline(); });
+        return shutdown_complete_;
     }
+    auto close_pipeline() noexcept -> void { pipeline_.Close(); }
 
     auto do_work() noexcept
     {
         rate_limit_state_machine();
         state_machine_queued_.store(false);
-        repeat(downcast().state_machine());
+        if (state_machine()) { trigger(); }
+        last_executed_ = Clock::now();
     }
     auto init_executor(const Endpoints endpoints = {}) noexcept -> void
     {
@@ -87,59 +103,67 @@ protected:
             pipeline_.SubscribeTo(endpoint);
         }
     }
-    auto stop_worker() noexcept -> std::shared_future<void>
-    {
-        pipeline_.Close();
-        downcast().shutdown(shutdown_promise_);
-
-        return shutdown_;
-    }
 
     Worker(
         const API& api,
         const std::chrono::milliseconds rateLimit,
         const Vector<network::zeromq::SocketData>& extra = {}) noexcept
-        : api_(api)
-        , rate_limit_(rateLimit)
-        , running_(true)
-        , shutdown_promise_()
-        , shutdown_(shutdown_promise_.get_future())
-        , pipeline_(api.Network().ZeroMQ().Internal().Pipeline(
-              [this](auto&& in) { downcast().pipeline(std::move(in)); },
+        : api_{api}
+        , rate_limit_{rateLimit}
+        , running_{true}
+        , shutdown_promise_{}
+        , shutdown_complete_{shutdown_promise_.get_future()}
+        , shutdown_mutex_{}
+        , last_executed_{Clock::now()}
+        , state_machine_queued_{false}
+        , pipeline_{api.Network().ZeroMQ().Internal().Pipeline(
+              [this](auto&& in) {
+                  if (running_) pipeline(std::move(in));
+              },
               {},
               {},
               {},
-              extra))
-        , last_executed_(Clock::now())
-        , state_machine_queued_(false)
+              extra)}
     {
         LogTrace()(OT_PRETTY_CLASS())("using ZMQ batch ")(pipeline_.BatchID())
             .Flush();
     }
 
-    ~Worker() { stop_worker().get(); }
+    virtual ~Worker()
+    {
+        protect_shutdown([this] { close_pipeline(); });
+    }
+
+    auto is_running() const noexcept { return running_.load(); }
+
+    void protect_shutdown(std::function<void()> funct)
+    {
+        bool running = true;
+
+        // Note: the lock is to hold up callers who will not get to
+        // trigger another shutdown functor execution but who could
+        // instead proceed to complete object destruction.
+        std::unique_lock<std::mutex> lock(shutdown_mutex_);
+
+        // Note: despite mutex protection, we use atomic here to avoid
+        // having to block the execution of the working thread.
+        bool can_do = running_.compare_exchange_strong(running, false);
+
+        if (can_do) {
+            funct();
+            shutdown_promise_.set_value();
+        }
+    }
 
 private:
-    Time last_executed_;
-    mutable std::atomic<bool> state_machine_queued_;
-
     auto rate_limit_state_machine() const noexcept
     {
-        const auto wait = std::chrono::duration_cast<std::chrono::milliseconds>(
-            rate_limit_ - (Clock::now() - last_executed_));
-
-        if (0 < wait.count()) { Sleep(wait); }
-    }
-
-    inline auto downcast() noexcept -> Child&
-    {
-        return static_cast<Child&>(*this);
-    }
-    auto repeat(const bool again) noexcept -> void
-    {
-        if (again) { trigger(); }
-
-        last_executed_ = Clock::now();
+        auto outstanding =
+            rate_limit_ - std::chrono::duration_cast<std::chrono::milliseconds>(
+                              Clock::now() - last_executed_);
+        if (0 < outstanding.count()) {
+            std::this_thread::sleep_for(outstanding);
+        }
     }
 };
 }  // namespace opentxs

--- a/src/interface/ui/accountactivity/AccountActivity.hpp
+++ b/src/interface/ui/accountactivity/AccountActivity.hpp
@@ -120,7 +120,7 @@ using AccountActivityList = List<
     states.
  */
 class AccountActivity : public AccountActivityList,
-                        protected Worker<AccountActivity>
+                        public Worker<api::session::Client>
 {
 public:
     auto AccountID() const noexcept -> UnallocatedCString final
@@ -275,8 +275,6 @@ protected:
         const SimpleCallback& cb) noexcept;
 
 private:
-    friend Worker<AccountActivity>;
-
     struct QT;
 
     QT* qt_;
@@ -289,7 +287,6 @@ private:
         CustomData& custom) const noexcept -> RowPointer final;
 
     auto init_qt() noexcept -> void;
-    virtual auto pipeline(const Message& in) noexcept -> void = 0;
     auto shutdown_qt() noexcept -> void;
 
     AccountActivity() = delete;

--- a/src/interface/ui/accountactivity/BlockchainAccountActivity.hpp
+++ b/src/interface/ui/accountactivity/BlockchainAccountActivity.hpp
@@ -169,7 +169,13 @@ public:
 
     ~BlockchainAccountActivity() final;
 
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
+
 private:
+    auto shut_down() noexcept -> void;
+
     struct Progress {
         auto get_percentage() const noexcept -> double
         {
@@ -229,7 +235,6 @@ private:
         -> UnallocatedCString final;
 
     auto load_thread() noexcept -> void;
-    auto pipeline(const Message& in) noexcept -> void final;
     auto process_balance(const Message& in) noexcept -> void;
     auto process_block(const Message& in) noexcept -> void;
     auto process_contact(const Message& in) noexcept -> void;

--- a/src/interface/ui/accountactivity/CustodialAccountActivity.hpp
+++ b/src/interface/ui/accountactivity/CustodialAccountActivity.hpp
@@ -95,6 +95,13 @@ public:
 
     ~CustodialAccountActivity() final;
 
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
+
+private:
+    auto shut_down() noexcept -> void;
+
 private:
     using EventRow =
         std::pair<AccountActivitySortKey, const proto::PaymentEvent*>;
@@ -122,7 +129,6 @@ private:
     auto display_balance(opentxs::Amount value) const noexcept
         -> UnallocatedCString final;
 
-    auto pipeline(const Message& in) noexcept -> void final;
     auto process_balance(const Message& message) noexcept -> void;
     auto process_contact(const Message& message) noexcept -> void;
     auto process_notary(const Message& message) noexcept -> void;

--- a/src/interface/ui/accountlist/AccountList.hpp
+++ b/src/interface/ui/accountlist/AccountList.hpp
@@ -76,7 +76,8 @@ using AccountListList = List<
     AccountListSortKey,
     AccountListPrimaryID>;
 
-class AccountList final : public AccountListList, Worker<AccountList>
+class AccountList final : public AccountListList,
+                          public Worker<api::session::Client>
 {
 public:
     AccountList(
@@ -86,9 +87,14 @@ public:
 
     ~AccountList() final;
 
-private:
-    friend Worker<AccountList>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         shutdown = value(WorkType::Shutdown),
         custodial = value(WorkType::AccountUpdated),
@@ -128,7 +134,6 @@ private:
         UnitType type,
         Amount&& balance,
         UnallocatedCString&& name) noexcept -> void;
-    auto pipeline(Message&& in) noexcept -> void;
     auto process_custodial(Message&& message) noexcept -> void;
     auto process_blockchain(Message&& message) noexcept -> void;
     auto process_blockchain_balance(Message&& message) noexcept -> void;

--- a/src/interface/ui/accounttree/AccountTree.hpp
+++ b/src/interface/ui/accounttree/AccountTree.hpp
@@ -83,7 +83,8 @@ using AccountTreeList = List<
     AccountTreeSortKey,
     AccountTreePrimaryID>;
 
-class AccountTree final : public AccountTreeList, Worker<AccountTree>
+class AccountTree final : public AccountTreeList,
+                          public Worker<api::session::Client>
 {
 public:
     auto Debug() const noexcept -> UnallocatedCString final;
@@ -99,9 +100,14 @@ public:
 
     ~AccountTree() final;
 
-private:
-    friend Worker<AccountTree>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         shutdown = value(WorkType::Shutdown),
         custodial = value(WorkType::AccountUpdated),
@@ -166,7 +172,6 @@ private:
 
     auto add_children(ChildMap&& children) noexcept -> void;
     auto load() noexcept -> void;
-    auto pipeline(Message&& in) noexcept -> void;
     auto process_blockchain(Message&& message) noexcept -> void;
     auto process_blockchain_balance(Message&& message) noexcept -> void;
     auto process_custodial(Message&& message) noexcept -> void;

--- a/src/interface/ui/activitythread/ActivityThread.hpp
+++ b/src/interface/ui/activitythread/ActivityThread.hpp
@@ -151,7 +151,8 @@ using ActivityThreadList = List<
     ActivityThreadSortKey,
     ActivityThreadPrimaryID>;
 
-class ActivityThread final : public ActivityThreadList, Worker<ActivityThread>
+class ActivityThread final : public ActivityThreadList,
+                             public Worker<api::session::Client>
 {
 public:
     auto CanMessage() const noexcept -> bool final;
@@ -185,9 +186,14 @@ public:
 
     ~ActivityThread() final;
 
-private:
-    friend Worker<ActivityThread>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         shutdown = value(WorkType::Shutdown),
         contact = value(WorkType::ContactUpdated),
@@ -231,7 +237,6 @@ private:
     auto load_contacts(const proto::StorageThread& thread) noexcept -> void;
     auto load_thread(const proto::StorageThread& thread) noexcept -> void;
     auto new_thread() noexcept -> void;
-    auto pipeline(Message&& in) noexcept -> void;
     auto process_contact(const Message& message) noexcept -> void;
     auto process_item(const proto::StorageThreadItem& item) noexcept(false)
         -> ActivityThreadRowID;
@@ -241,7 +246,6 @@ private:
     auto process_thread(const Message& message) noexcept -> void;
     auto refresh_thread() noexcept -> void;
     auto set_participants() noexcept -> void;
-    auto state_machine() noexcept -> bool final;
     auto startup() noexcept -> void;
     auto update_display_name() noexcept -> bool;
     auto update_messagability(otx::client::Messagability value) noexcept

--- a/src/interface/ui/base/List.hpp
+++ b/src/interface/ui/base/List.hpp
@@ -94,16 +94,6 @@ public:
     {
         return qt_model_;
     }
-    auto shutdown(std::promise<void>& promise) noexcept -> void
-    {
-        wait_for_startup();
-
-        try {
-            promise.set_value();
-        } catch (...) {
-        }
-    }
-    virtual auto state_machine() noexcept -> bool { return false; }
 
     ~List() override
     {
@@ -226,7 +216,15 @@ protected:
 
         return std::future_status::ready == startup_future_.wait_for(none);
     }
-    auto wait_for_startup() const noexcept -> void { startup_future_.get(); }
+    auto wait_for_startup() const noexcept -> void
+    {
+        try {
+            startup_future_.get();
+        } catch (const std::exception& e) {
+            LogError()(OT_PRETTY_CLASS())(e.what()).Flush();
+            // TODO MT-34 improve
+        }
+    }
 
     auto add_item(
         const RowID& id,

--- a/src/interface/ui/blockchainaccountstatus/BlockchainAccountStatus.hpp
+++ b/src/interface/ui/blockchainaccountstatus/BlockchainAccountStatus.hpp
@@ -71,7 +71,7 @@ using BlockchainAccountStatusType = List<
     BlockchainAccountStatusPrimaryID>;
 
 class BlockchainAccountStatus final : public BlockchainAccountStatusType,
-                                      Worker<BlockchainAccountStatus>
+                                      public Worker<api::session::Client>
 {
 public:
     auto Chain() const noexcept -> blockchain::Type final { return chain_; }
@@ -88,9 +88,14 @@ public:
 
     ~BlockchainAccountStatus() final;
 
-private:
-    friend Worker<BlockchainAccountStatus>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         shutdown = value(WorkType::Shutdown),
         newaccount = value(WorkType::BlockchainAccountCreated),
@@ -138,7 +143,6 @@ private:
 
     auto add_children(ChildMap&& children) noexcept -> void;
     auto load() noexcept -> void;
-    auto pipeline(Message&& in) noexcept -> void;
     auto process_account(const Message& in) noexcept -> void;
     auto process_progress(const Message& in) noexcept -> void;
     auto process_reorg(const Message& in) noexcept -> void;

--- a/src/interface/ui/blockchainselection/BlockchainSelection.hpp
+++ b/src/interface/ui/blockchainselection/BlockchainSelection.hpp
@@ -105,7 +105,7 @@ using BlockchainSelectionList = List<
     BlockchainSelectionPrimaryID>;
 
 class BlockchainSelection final : public BlockchainSelectionList,
-                                  Worker<BlockchainSelection>
+                                  public Worker<api::session::Client>
 {
 public:
     auto Disable(const blockchain::Type type) const noexcept -> bool final;
@@ -120,9 +120,13 @@ public:
 
     ~BlockchainSelection() final;
 
-private:
-    friend Worker<BlockchainSelection>;
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     struct Callback {
         auto run(blockchain::Type chain, bool enabled, std::size_t total)
             const noexcept -> void
@@ -168,7 +172,6 @@ private:
         CustomData& custom) const noexcept -> RowPointer final;
     auto disable(const Message& in) noexcept -> void;
     auto enable(const Message& in) noexcept -> void;
-    auto pipeline(const Message& in) noexcept -> void;
     auto process_state(const Message& in) noexcept -> void;
     auto startup() noexcept -> void;
 

--- a/src/interface/ui/blockchainstatistics/BlockchainStatistics.hpp
+++ b/src/interface/ui/blockchainstatistics/BlockchainStatistics.hpp
@@ -88,7 +88,7 @@ using BlockchainStatisticsList = List<
     BlockchainStatisticsPrimaryID>;
 
 class BlockchainStatistics final : public BlockchainStatisticsList,
-                                   Worker<BlockchainStatistics>
+                                   public Worker<api::session::Client>
 {
 public:
     BlockchainStatistics(
@@ -97,9 +97,14 @@ public:
 
     ~BlockchainStatistics() final;
 
-private:
-    friend Worker<BlockchainStatistics>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         shutdown = value(WorkType::Shutdown),
         blockheader = value(WorkType::BlockchainNewHeader),
@@ -134,7 +139,6 @@ private:
     auto custom(const BlockchainStatisticsRowID& chain) noexcept -> CustomData;
     auto get_cache(const BlockchainStatisticsRowID& chain) noexcept(false)
         -> CachedData&;
-    auto pipeline(const Message& in) noexcept -> void;
     auto process_balance(const Message& in) noexcept -> void;
     auto process_block(const Message& in) noexcept -> void;
     auto process_block_header(const Message& in) noexcept -> void;

--- a/src/interface/ui/contactlist/ContactList.hpp
+++ b/src/interface/ui/contactlist/ContactList.hpp
@@ -98,7 +98,7 @@ using ContactListList = List<
 
 class ContactList final : virtual public internal::ContactList,
                           public ContactListList,
-                          Worker<ContactList>
+                          public Worker<api::session::Client>
 {
 public:
     auto AddContact(
@@ -117,9 +117,14 @@ public:
         const SimpleCallback& cb) noexcept;
     ~ContactList() final;
 
-private:
-    friend Worker<ContactList>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         contact = value(WorkType::ContactUpdated),
         init = OT_ZMQ_INIT_SIGNAL,
@@ -159,7 +164,6 @@ private:
         return owner_contact_id_;
     }
 
-    auto pipeline(const Message& in) noexcept -> void;
     auto process_contact(const Message& message) noexcept -> void;
     auto process_contact(const Identifier& contactID) noexcept -> void;
     auto startup() noexcept -> void;

--- a/src/interface/ui/messagablelist/MessagableList.hpp
+++ b/src/interface/ui/messagablelist/MessagableList.hpp
@@ -68,7 +68,8 @@ using MessagableListList = List<
     MessagableListSortKey,
     MessagableListPrimaryID>;
 
-class MessagableList final : public MessagableListList, Worker<MessagableList>
+class MessagableList final : public MessagableListList,
+                             public Worker<api::session::Client>
 {
 public:
     auto ID() const noexcept -> const Identifier& final
@@ -82,9 +83,14 @@ public:
         const SimpleCallback& cb) noexcept;
     ~MessagableList() final;
 
-private:
-    friend Worker<MessagableList>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         contact = value(WorkType::ContactUpdated),
         nym = value(WorkType::NymUpdated),
@@ -104,7 +110,6 @@ private:
         return MessagableListList::last(id);
     }
 
-    auto pipeline(const Message& in) noexcept -> void;
     auto process_contact(
         const MessagableListRowID& id,
         const MessagableListSortKey& key) noexcept -> void;

--- a/src/interface/ui/nymlist/NymList.hpp
+++ b/src/interface/ui/nymlist/NymList.hpp
@@ -69,16 +69,21 @@ using NymListList = List<
     NymListSortKey,
     NymListPrimaryID>;
 
-class NymList final : public NymListList, Worker<NymList>
+class NymList final : public NymListList, public Worker<api::session::Client>
 {
 public:
     NymList(const api::session::Client& api, const SimpleCallback& cb) noexcept;
 
     ~NymList() final;
 
-private:
-    friend Worker<NymList>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         newnym = value(WorkType::NymCreated),
         nymchanged = value(WorkType::NymUpdated),
@@ -94,7 +99,6 @@ private:
 
     auto load() noexcept -> void;
     auto load(OTNymID&& id) noexcept -> void;
-    auto pipeline(Message&& in) noexcept -> void;
     auto process_new_nym(Message&& in) noexcept -> void;
     auto process_nym_changed(Message&& in) noexcept -> void;
     auto startup() noexcept -> void;

--- a/src/interface/ui/payablelist/PayableList.hpp
+++ b/src/interface/ui/payablelist/PayableList.hpp
@@ -73,7 +73,8 @@ using PayableListList = List<
     PayableListSortKey,
     PayablePrimaryID>;
 
-class PayableList final : public PayableListList, Worker<PayableList>
+class PayableList final : public PayableListList,
+                          public Worker<api::session::Client>
 {
 public:
     auto ID() const noexcept -> const Identifier& final
@@ -88,9 +89,14 @@ public:
         const SimpleCallback& cb) noexcept;
     ~PayableList() final;
 
-private:
-    friend Worker<PayableList>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         contact = value(WorkType::ContactUpdated),
         nym = value(WorkType::NymUpdated),
@@ -111,7 +117,6 @@ private:
         return PayableListList::last(id);
     }
 
-    auto pipeline(const Message& in) noexcept -> void;
     auto process_contact(
         const PayableListRowID& id,
         const PayableListSortKey& key) noexcept -> void;

--- a/src/interface/ui/seedtree/SeedTree.hpp
+++ b/src/interface/ui/seedtree/SeedTree.hpp
@@ -90,7 +90,7 @@ using SeedTreeList = List<
     SeedTreeSortKey,
     SeedTreePrimaryID>;
 
-class SeedTree final : public SeedTreeList, Worker<SeedTree>
+class SeedTree final : public SeedTreeList, public Worker<api::session::Client>
 {
 public:
     auto ClearCallbacks() const noexcept -> void final;
@@ -106,9 +106,14 @@ public:
 
     ~SeedTree() final;
 
-private:
-    friend Worker<SeedTree>;
+protected:
+    auto pipeline(Message&& in) noexcept -> void final;
+    auto state_machine() noexcept -> bool final;
 
+private:
+    auto shut_down() noexcept -> void;
+
+private:
     enum class Work : OTZMQWorkType {
         shutdown = value(WorkType::Shutdown),
         new_nym = value(WorkType::NymCreated),
@@ -154,7 +159,6 @@ private:
     auto check_default_nym() noexcept -> void;
     auto check_default_seed() noexcept -> void;
     auto load() noexcept -> void;
-    auto pipeline(Message&& in) noexcept -> void;
     auto process_nym(Message&& in) noexcept -> void;
     auto process_nym(const identifier::Nym& id) noexcept -> void;
     auto process_seed(Message&& in) noexcept -> void;

--- a/src/internal/blockchain/node/Node.hpp
+++ b/src/internal/blockchain/node/Node.hpp
@@ -467,7 +467,7 @@ struct PeerManager {
         const noexcept -> void = 0;
 
     virtual auto init() noexcept -> void = 0;
-    virtual auto Shutdown() noexcept -> std::shared_future<void> = 0;
+    virtual auto Shutdown() noexcept -> void = 0;
 
     virtual ~PeerManager() = default;
 };
@@ -525,7 +525,7 @@ struct Network : virtual public node::Manager {
         const block::Position position) const noexcept -> void = 0;
 
     virtual auto FilterOracleInternal() noexcept -> internal::FilterOracle& = 0;
-    virtual auto Shutdown() noexcept -> std::shared_future<void> = 0;
+    virtual auto Shutdown() noexcept -> void = 0;
     virtual auto StartWallet() noexcept -> void = 0;
 
     ~Network() override = default;
@@ -564,7 +564,7 @@ struct Wallet : virtual public node::Wallet {
     virtual auto FeeEstimate() const noexcept -> std::optional<Amount> = 0;
 
     virtual auto Init() noexcept -> void = 0;
-    virtual auto Shutdown() noexcept -> std::shared_future<void> = 0;
+    virtual auto Shutdown() noexcept -> void = 0;
 
     ~Wallet() override = default;
 };

--- a/src/internal/blockchain/p2p/P2P.hpp
+++ b/src/internal/blockchain/p2p/P2P.hpp
@@ -41,13 +41,14 @@ struct Address : virtual public p2p::Address {
     virtual auto PreviousLastConnected() const noexcept -> Time = 0;
     virtual auto PreviousServices() const noexcept
         -> UnallocatedSet<Service> = 0;
+    virtual int diag() { return -1; }
 
     ~Address() override = default;
 };
 
 struct Peer : virtual public p2p::Peer {
     virtual auto AddressID() const noexcept -> OTIdentifier = 0;
-    virtual auto Shutdown() noexcept -> std::shared_future<void> = 0;
+    virtual auto Shutdown() noexcept -> void = 0;
 
     virtual ~Peer() override = default;
 };

--- a/src/network/zeromq/message/Frame.cpp
+++ b/src/network/zeromq/message/Frame.cpp
@@ -159,6 +159,8 @@ auto Frame::Bytes() const noexcept -> ReadView { return imp_->Bytes(); }
 
 auto Frame::data() const noexcept -> const void* { return imp_->data(); }
 
+auto Frame::data() noexcept -> void* { return imp_->data(); }
+
 auto Frame::Internal() const noexcept -> const internal::Frame&
 {
     return *imp_;

--- a/src/network/zeromq/message/Message.cpp
+++ b/src/network/zeromq/message/Message.cpp
@@ -166,9 +166,9 @@ auto Message::Imp::AddFrame(const ProtobufType& input) noexcept -> Frame&
 auto Message::Imp::AppendBytes() noexcept -> AllocateOutput
 {
     return [this](const std::size_t size) -> WritableView {
-        auto& frame = frames_.emplace_back(factory::ZMQFrame(size));
+        Frame& frame = frames_.emplace_back(factory::ZMQFrame(size));
 
-        return {const_cast<void*>(frame.data()), frame.size()};
+        return WritableView{frame.data(), frame.size()};
     };
 }
 
@@ -177,7 +177,7 @@ auto Message::Imp::at(const std::size_t index) const noexcept(false)
 {
     OT_ASSERT(frames_.size() > index);
 
-    return const_cast<const Frame&>(frames_.at(index));
+    return frames_.at(index);
 }
 
 auto Message::Imp::at(const std::size_t index) noexcept(false) -> Frame&
@@ -189,9 +189,8 @@ auto Message::Imp::at(const std::size_t index) noexcept(false) -> Frame&
 
 auto Message::Imp::begin() const noexcept -> const FrameIterator
 {
-    return FrameIterator{std::make_unique<FrameIterator::Imp>(
-                             const_cast<zeromq::Message*>(parent_))
-                             .release()};
+    return FrameIterator{
+        std::make_unique<FrameIterator::Imp>(parent_).release()};
 }
 
 auto Message::Imp::Body() const noexcept -> const FrameSection
@@ -240,8 +239,7 @@ auto Message::Imp::body_position() const noexcept -> std::size_t
 auto Message::Imp::end() const noexcept -> const FrameIterator
 {
     return FrameIterator{
-        std::make_unique<FrameIterator::Imp>(
-            const_cast<zeromq::Message*>(parent_), frames_.size())
+        std::make_unique<FrameIterator::Imp>(parent_, frames_.size())
             .release()};
 }
 

--- a/src/network/zeromq/socket/Raw.cpp
+++ b/src/network/zeromq/socket/Raw.cpp
@@ -234,6 +234,12 @@ auto Raw::send(Message&& msg, const int baseFlags) noexcept -> bool
     if (false == sent) {
         std::cerr << (OT_PRETTY_CLASS())
                   << "Send error: " << ::zmq_strerror(zmq_errno()) << '\n';
+        std::cerr << "bound_endpoints_: ";
+        for (const auto& s : bound_endpoints_) { std::cerr << s << " "; }
+        std::cerr << std::endl;
+        std::cerr << "connected_endpoints_: ";
+        for (const auto& s : connected_endpoints_) { std::cerr << s << " "; }
+        std::cerr << std::endl;
     }
 
     return sent;

--- a/src/otx/common/OTTransaction.cpp
+++ b/src/otx/common/OTTransaction.cpp
@@ -435,8 +435,6 @@ void OTTransaction::SetClosingNum(std::int64_t lClosingNum)
 //
 auto OTTransaction::VerifyAccount(const identity::Nym& theNym) -> bool
 {
-    auto* pParent = const_cast<Ledger*>(m_pParent);
-
     // Make sure that the supposed AcctID matches the one read from the file.
     //
     if (!VerifyContractID()) {
@@ -445,8 +443,8 @@ auto OTTransaction::VerifyAccount(const identity::Nym& theNym) -> bool
     }
     // todo security audit:
     else if (
-        IsAbbreviated() && (pParent != nullptr) &&
-        !pParent->VerifySignature(theNym)) {
+        IsAbbreviated() && (m_pParent != nullptr) &&
+        !m_pParent->VerifySignature(theNym)) {
         LogError()(OT_PRETTY_CLASS())(
             "Error verifying signature on parent ledger "
             "for abbreviated transaction receipt.")


### PR DESCRIPTION
This solves the issue of some virtual calls out of the base destructor, clash between different shutdown/destruction paths, unclear access with friend classes plus a number of small bugs. The mutual exclusion of shutdown actions addresses SEGFAULT observed in testing.
Also, some spurious additional delays and unneeded thread yields have been removed, together with a couple of the most obnoxious of the many const_casts.