### PR TITLE
OT-385_openssl_3x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,6 +564,26 @@ find_package(
   REQUIRED
 )
 
+string(
+  REGEX
+    MATCH
+    "[0-9]*"
+    OPENSSL_MAJOR
+    "${OPENSSL_VERSION}"
+)
+
+if("${OPENSSL_MAJOR}"
+   GREATER_EQUAL
+   3
+)
+  if(OT_CASH_USING_LUCRE)
+    message(
+      WARNING
+        "Lucre is not compatible with OpenSSL 3. You will receive runtime errors when attempting to use blinded instruments"
+    )
+  endif()
+endif()
+
 if(OT_CRYPTO_USING_LIBSECP256K1 AND NOT OT_BUNDLED_SECP256K1)
   find_package(unofficial-secp256k1 REQUIRED)
 endif()

--- a/src/crypto/library/openssl/OpenSSL.hpp
+++ b/src/crypto/library/openssl/OpenSSL.hpp
@@ -15,6 +15,12 @@ extern "C" {
 #include <openssl/rsa.h>
 }
 
+#if __has_include(<openssl/provider.h>)
+extern "C" {
+#include <openssl/provider.h>
+}
+#endif
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -133,7 +139,7 @@ public:
     auto operator=(const OpenSSL&) -> OpenSSL& = delete;
     auto operator=(OpenSSL&&) -> OpenSSL& = delete;
 
-    ~OpenSSL() final = default;
+    ~OpenSSL() final;
 
 private:
     struct BIO {
@@ -205,6 +211,11 @@ private:
     };
 
     using Instantiate = std::function<::EVP_PKEY*(::BIO*)>;
+
+#if __has_include(<openssl/provider.h>)
+    OSSL_PROVIDER* default_provider_;
+    OSSL_PROVIDER* legacy_provider_;
+#endif
 
     static auto init_key(
         const ReadView bytes,


### PR DESCRIPTION
- introduced support for openssl 3x in mf/ot, based on ot/ot