### PR TITLE
CAS-90 wallet CI

### DIFF
--- a/vcpkg/vcpkg-nonwindows.txt
+++ b/vcpkg/vcpkg-nonwindows.txt
@@ -29,4 +29,4 @@ protobuf
 qt5-base
 qt5-declarative
 sqlite3
-zeromq[sodium]
+zeromq

--- a/vcpkg/vcpkg.txt
+++ b/vcpkg/vcpkg.txt
@@ -29,4 +29,4 @@ pthread
 qt5-base
 qt5-declarative
 sqlite3
-zeromq[sodium]
+zeromq


### PR DESCRIPTION
- vcpkg deps cannot have specializer in order for vcpkg export command to work properly in the mode that we need it to in CI