### PR TITLE
OT-387_ci_windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,8 @@ set_rpath()
 # -----------------------------------------------------------------------------
 # Set option defaults
 
-if(CMAKE_BUILD_TYPE
-   STREQUAL
-   "Debug"
-)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+   CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   set(OPENTXS_DEBUG_BUILD ON)
   set(OPENTXS_PEDANTIC_DEFAULT ON)
   set(OPENTXS_BUILD_TESTS_DEFAULT ON)
@@ -311,11 +309,9 @@ endif()
 
 if(OPENTXS_BUILD_TESTS
    AND NOT
-       (CMAKE_BUILD_TYPE
-        STREQUAL
-        "Debug")
-)
-  message(FATAL_ERROR "opentxs unit tests require CMAKE_BUILD_TYPE=Debug")
+       ((CMAKE_BUILD_TYPE STREQUAL "Debug") OR
+        (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")))
+  message(FATAL_ERROR "opentxs unit tests require CMAKE_BUILD_TYPE=Debug|RelWithDebInfo")
 endif()
 
 # -----------------------------------------------------------------------------

--- a/include/opentxs/blockchain/bitcoin/cfilter/Hash.hpp
+++ b/include/opentxs/blockchain/bitcoin/cfilter/Hash.hpp
@@ -48,7 +48,6 @@ struct OPENTXS_EXPORT less<opentxs::blockchain::cfilter::Hash> {
 
 namespace opentxs::blockchain::cfilter
 {
-// NOTE sorry Windows users, MSVC throws an ICE if we export this symbol
 class OPENTXS_EXPORT_TEMPLATE Hash : virtual public FixedByteArray<32>
 {
 public:

--- a/include/opentxs/blockchain/bitcoin/cfilter/Header.hpp
+++ b/include/opentxs/blockchain/bitcoin/cfilter/Header.hpp
@@ -48,7 +48,6 @@ struct OPENTXS_EXPORT less<opentxs::blockchain::cfilter::Header> {
 
 namespace opentxs::blockchain::cfilter
 {
-// NOTE sorry Windows users, MSVC throws an ICE if we export this symbol
 class OPENTXS_EXPORT_TEMPLATE Header : virtual public FixedByteArray<32>
 {
 public:

--- a/include/opentxs/blockchain/block/Hash.hpp
+++ b/include/opentxs/blockchain/block/Hash.hpp
@@ -48,7 +48,6 @@ struct OPENTXS_EXPORT less<opentxs::blockchain::block::Hash> {
 
 namespace opentxs::blockchain::block
 {
-// NOTE sorry Windows users, MSVC throws an ICE if we export this symbol
 class OPENTXS_EXPORT_TEMPLATE Hash : virtual public FixedByteArray<32>
 {
 public:

--- a/include/opentxs/core/FixedByteArray.hpp
+++ b/include/opentxs/core/FixedByteArray.hpp
@@ -116,8 +116,11 @@ private:
     auto clone() const -> Data* override;
 };
 
+#if defined(_WIN32) || defined(_WIN64)
 // NOTE sorry Windows users, MSVC throws an ICE if we export this symbol
+#else
 extern template class OPENTXS_EXPORT_TEMPLATE FixedByteArray<32>;
+#endif
 }  // namespace opentxs
 
 namespace std

--- a/src/api/crypto/eliptic_curve/Secp256k1.cpp
+++ b/src/api/crypto/eliptic_curve/Secp256k1.cpp
@@ -45,7 +45,7 @@ bool is_compressed_pubkey_correct_size(std::size_t const pubkey_length)
 
 bool is_pubkey_compressed(std::string_view key_prefix)
 {
-    return is_pubkey_starts_from_even_prefix(key_prefix) or
+    return is_pubkey_starts_from_even_prefix(key_prefix) ||
            is_pubkey_starts_from_odd_prefix(key_prefix);
 }
 

--- a/src/blockchain/block/Position.cpp
+++ b/src/blockchain/block/Position.cpp
@@ -29,7 +29,7 @@ Position::Position(const Height& height, const Hash& hash) noexcept
 }
 
 Position::Position(const Height& height, Hash&& hash) noexcept
-    : Position(Height{height}, std::move(hash))
+    : Position(std::move(Height{height}), std::move(hash))
 {
 }
 

--- a/src/core/FixedByteArray.cpp
+++ b/src/core/FixedByteArray.cpp
@@ -9,5 +9,9 @@
 
 namespace opentxs
 {
+#if defined(_WIN32) || defined(_WIN64)
+// NOTE sorry Windows users, MSVC throws an ICE if we export this symbol
+#else
 template class FixedByteArray<32>;
+#endif
 }  // namespace opentxs

--- a/src/core/paymentcode/Imp.cpp
+++ b/src/core/paymentcode/Imp.cpp
@@ -183,8 +183,8 @@ auto PaymentCode::apply_mask(
 {
     static_assert(34 == sizeof(pre));
 
-    auto* i = std::next(pre.key_.begin());
-    auto* const end = pre.key_.end();
+    auto i = std::next(pre.key_.begin());
+    auto const end = pre.key_.end();
 
     for (const auto& m : mask) {
         auto& byte = *i;

--- a/src/util/platform/CMakeLists.txt
+++ b/src/util/platform/CMakeLists.txt
@@ -14,6 +14,8 @@ if(WIN32)
 
   if(OPENTXS_DEBUG_BUILD)
     target_sources(opentxs-common PRIVATE "Windows_debug.cpp")
+  else()
+    target_sources(opentxs-common PRIVATE "Windows_release.cpp")
   endif()
 
   target_include_directories(

--- a/tests/ottest/data/blockchain/CMakeLists.txt
+++ b/tests/ottest/data/blockchain/CMakeLists.txt
@@ -8,9 +8,17 @@ target_sources(
   PRIVATE
     "Bip158.cpp"
     "Bip158.hpp"
-    "bch_filter_1307544.cpp"
-    "bch_filter_1307723.cpp"
+    #"bch_filter_1307544.cpp"
+    #"bch_filter_1307723.cpp"
 )
+if(NOT MSVC)
+  target_sources(
+    ottest
+    PRIVATE
+      "bch_filter_1307544.cpp"
+      "bch_filter_1307723.cpp"
+)
+endif()
 
 if(OT_BLOCKCHAIN_EXPORT AND NOT MSVC)
   # NOTE the RLP test vectors can not be easily embedded when the compiler is


### PR DESCRIPTION
- wip
- fix FixedByteArray templating problem with msvc
- disable bch_filter_*.cpp build as msvc cannot compile those
- fix Position constructor
- fix tests build for windows